### PR TITLE
Remove `Matches` attribute on `FingerprintMatch`, fix db bug

### DIFF
--- a/cmd/recog_match/main.go
+++ b/cmd/recog_match/main.go
@@ -29,8 +29,7 @@ func visit(files *[]string) filepath.WalkFunc {
 
 func fingerprint(fingerprints []recog.FingerprintDB, text string) {
 	for _, fdb := range fingerprints {
-		match := fdb.MatchFirst(text)
-		if match.Matched {
+		if match := fdb.MatchFirst(text); match != nil {
 			j, _ := json.Marshal(match.Values)
 			fmt.Printf("%s\n", j)
 		}

--- a/fingerprints_test.go
+++ b/fingerprints_test.go
@@ -18,117 +18,118 @@ func TestFingerprints(t *testing.T) {
 		t.Fatalf("LoadFingerprints() failed:: %s", err)
 	}
 
-	for _, fdb := range fset.Databases {
-		name := fdb.Name
-		fdb := fdb
+	for matchKey, fdbs := range fset.DatabasesByMatchKey {
+		name := matchKey
 		if !strings.HasSuffix(name, ".xml") {
 			continue
 		}
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			if preference, err := strconv.ParseFloat(fdb.Preference, 32); err == nil && (preference <= .1 || preference > .9) {
-				t.Error("fingerprint db preference should be between 0.1 - 0.9")
-			}
-
-			descriptions := make(set)
-			for i, fp := range fdb.Fingerprints {
-				i := i
-				fp := fp
-				if fp.Description == nil {
-					t.Errorf("has nil description: %v", fp)
-					continue
-				}
-				if descriptions.contains(fp.Description.Text) {
-					t.Errorf("has a duplicate fingerprint description: %q", fp.Description.Text)
-				} else {
-					descriptions.add(fp.Description.Text)
+		for _, fdb := range fdbs {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				if preference, err := strconv.ParseFloat(fdb.Preference, 32); err == nil && (preference <= .1 || preference > .9) {
+					t.Error("fingerprint db preference should be between 0.1 - 0.9")
 				}
 
-				if len(fp.Params) == 0 {
-					t.Errorf("should assert facts about data or set certainty params to 0.0: %v", fp.Description.Text)
-				}
-
-				t.Run(fp.Description.Text, func(t *testing.T) {
-					if reGroupedCaseSensitivity.MatchString(fp.Pattern) {
-						t.Errorf("regex case-sensitivity flag should be at the start of the regex: %s", fp.Pattern)
+				descriptions := make(set)
+				for i, fp := range fdb.Fingerprints {
+					i := i
+					fp := fp
+					if fp.Description == nil {
+						t.Errorf("has nil description: %v", fp)
+						continue
+					}
+					if descriptions.contains(fp.Description.Text) {
+						t.Errorf("has a duplicate fingerprint description: %q", fp.Description.Text)
+					} else {
+						descriptions.add(fp.Description.Text)
 					}
 
-					if reGroupedMultiline.MatchString(fp.Pattern) {
-						t.Errorf("regex multiline flag should be at the start of the regex: %s", fp.Pattern)
+					if len(fp.Params) == 0 {
+						t.Errorf("should assert facts about data or set certainty params to 0.0: %v", fp.Description.Text)
 					}
 
-					params := make(set)
-					captures := make(set)
-					var hwDevice, osDevice string
-					for _, param := range fp.Params {
-						param := param
-						pos, _ := strconv.Atoi(param.Position)
-						val := strings.TrimSpace(param.Value)
-						if !reParamName.MatchString(param.Name) {
-							t.Errorf("fingerprint parameter name is invalid: %q", param.Name)
-						} else if params.contains(param.Name) {
-							t.Errorf("has a duplicate fingerprint parameter: %q", param.Name)
-						} else {
-							params.add(param.Name)
+					t.Run(fp.Description.Text, func(t *testing.T) {
+						if reGroupedCaseSensitivity.MatchString(fp.Pattern) {
+							t.Errorf("regex case-sensitivity flag should be at the start of the regex: %s", fp.Pattern)
 						}
 
-						if param.Name == "os.device" {
-							osDevice = val
-						} else if param.Name == "hw.device" {
-							hwDevice = val
+						if reGroupedMultiline.MatchString(fp.Pattern) {
+							t.Errorf("regex multiline flag should be at the start of the regex: %s", fp.Pattern)
 						}
 
-						if pos > 0 {
-							captures.add(pos)
-						}
+						params := make(set)
+						captures := make(set)
+						var hwDevice, osDevice string
+						for _, param := range fp.Params {
+							param := param
+							pos, _ := strconv.Atoi(param.Position)
+							val := strings.TrimSpace(param.Value)
+							if !reParamName.MatchString(param.Name) {
+								t.Errorf("fingerprint parameter name is invalid: %q", param.Name)
+							} else if params.contains(param.Name) {
+								t.Errorf("has a duplicate fingerprint parameter: %q", param.Name)
+							} else {
+								params.add(param.Name)
+							}
 
-						if pos > 0 && val != "" {
-							t.Errorf("parameter %q is set from a capture group(%d), but a value was provided", param.Name, pos)
-						}
+							if param.Name == "os.device" {
+								osDevice = val
+							} else if param.Name == "hw.device" {
+								hwDevice = val
+							}
 
-						if pos == 0 && val == "" {
-							t.Errorf("%s is not a capture (pos=0) but no value was provided", param.Name)
-						}
+							if pos > 0 {
+								captures.add(pos)
+							}
 
-						if pos == 0 && reInterpolation.MatchString(val) {
-							found := false
-							match := reInterpolation.FindStringSubmatch(val)
-							interpolated := match[reInterpolation.SubexpIndex("interpolated")]
-							for _, p := range fp.Params {
-								if p.Name == interpolated {
-									found = true
+							if pos > 0 && val != "" {
+								t.Errorf("parameter %q is set from a capture group(%d), but a value was provided", param.Name, pos)
+							}
+
+							if pos == 0 && val == "" {
+								t.Errorf("%s is not a capture (pos=0) but no value was provided", param.Name)
+							}
+
+							if pos == 0 && reInterpolation.MatchString(val) {
+								found := false
+								match := reInterpolation.FindStringSubmatch(val)
+								interpolated := match[reInterpolation.SubexpIndex("interpolated")]
+								for _, p := range fp.Params {
+									if p.Name == interpolated {
+										found = true
+									}
+								}
+								if !found {
+									t.Errorf("%q uses interpolated value %q that does not exist in list of fingerprint parameters", param.Name, interpolated)
 								}
 							}
-							if !found {
-								t.Errorf("%q uses interpolated value %q that does not exist in list of fingerprint parameters", param.Name, interpolated)
+						}
+
+						if (hwDevice != "" && osDevice != "") && osDevice != hwDevice {
+							t.Errorf("has both hw.device and os.device but with differing values")
+						}
+
+						captureGroups := captures.len()
+						if fp.PatternCompiled.NumSubexp() != captureGroups {
+							t.Errorf("regex has %d capture groups, but the fingerprint expected %d extraction(s)", fp.PatternCompiled.NumSubexp(), captureGroups)
+						}
+
+						if i == 0 {
+							return
+						}
+
+						for j := 0; j < i; j++ {
+							previousFp := fdb.Fingerprints[j]
+							for _, example := range fp.Examples {
+								if match := previousFp.Match(example.Text); match != nil {
+									t.Errorf("regex matched previous fingerprint: %s; consider reordering the fingerprints", previousFp.Description.Text)
+								}
 							}
 						}
-					}
-
-					if (hwDevice != "" && osDevice != "") && osDevice != hwDevice {
-						t.Errorf("has both hw.device and os.device but with differing values")
-					}
-
-					captureGroups := captures.len()
-					if fp.PatternCompiled.NumSubexp() != captureGroups {
-						t.Errorf("regex has %d capture groups, but the fingerprint expected %d extraction(s)", fp.PatternCompiled.NumSubexp(), captureGroups)
-					}
-
-					if i == 0 {
-						return
-					}
-
-					for j := 0; j < i; j++ {
-						previousFp := fdb.Fingerprints[j]
-						for _, example := range fp.Examples {
-							if match := previousFp.Match(example.Text); match.Matched {
-								t.Errorf("regex matched previous fingerprint: %s; consider reordering the fingerprints", previousFp.Description.Text)
-							}
-						}
-					}
-				})
-			}
-		})
+					})
+				}
+			})
+		}
 	}
 }
 

--- a/fingerprints_test.go
+++ b/fingerprints_test.go
@@ -18,8 +18,8 @@ func TestFingerprints(t *testing.T) {
 		t.Fatalf("LoadFingerprints() failed:: %s", err)
 	}
 
-	for name, fdb := range fset.Databases {
-		name := name
+	for _, fdb := range fset.Databases {
+		name := fdb.Name
 		fdb := fdb
 		if !strings.HasSuffix(name, ".xml") {
 			continue

--- a/nition.go
+++ b/nition.go
@@ -13,37 +13,49 @@ import (
 
 // FingerprintSet is a collection of loaded Recog fingerprint databases
 type FingerprintSet struct {
-	Databases map[string]*FingerprintDB
+	Databases []*FingerprintDB
 	Logger    *log.Logger
 }
 
 // NewFingerprintSet returns an allocated FingerprintSet structure
 func NewFingerprintSet() *FingerprintSet {
 	fs := &FingerprintSet{}
-	fs.Databases = make(map[string]*FingerprintDB)
+	fs.Databases = make([]*FingerprintDB, 0, 20)
 	return fs
 }
 
 // MatchFirst matches data to a given fingerprint database
 func (fs *FingerprintSet) MatchFirst(name string, data string) *FingerprintMatch {
-	nomatch := &FingerprintMatch{Matched: false}
-	fdb, ok := fs.Databases[name]
-	if !ok {
-		nomatch.Errors = append(nomatch.Errors, fmt.Errorf("database %s is missing", name))
-		return nomatch
+	found := false
+	for _, fdb := range fs.Databases {
+		if fdb.Matches == name || fdb.Name == name {
+			found = true
+			return fdb.MatchFirst(data)
+		}
 	}
-	return fdb.MatchFirst(data)
+
+	nomatch := &FingerprintMatch{Matched: false}
+	if !found {
+		nomatch.Errors = append(nomatch.Errors, fmt.Errorf("database %s is missing", name))
+	}
+	return nomatch
 }
 
 // MatchAll matches data to a given fingerprint database
 func (fs *FingerprintSet) MatchAll(name string, data string) []*FingerprintMatch {
-	nomatch := &FingerprintMatch{Matched: false}
-	fdb, ok := fs.Databases[name]
-	if !ok {
-		nomatch.Errors = append(nomatch.Errors, fmt.Errorf("database %s is missing", name))
-		return []*FingerprintMatch{nomatch}
+	found := false
+	var matches []*FingerprintMatch
+	for _, fdb := range fs.Databases {
+		if fdb.Matches == name || fdb.Name == name {
+			found = true
+			matches = append(matches, fdb.MatchAll(data)...)
+		}
 	}
-	return fdb.MatchAll(data)
+
+	if !found {
+		matches = append(matches, &FingerprintMatch{Matched: false, Errors: []error{fmt.Errorf("database %s is missing", name)}})
+	}
+	return matches
 }
 
 // LoadFingerprints parses the embedded Recog XML databases, returning a FingerprintSet
@@ -94,11 +106,8 @@ func (fs *FingerprintSet) LoadFingerprintsFromFS(efs http.FileSystem) error {
 
 		fdb.Logger = fs.Logger
 
-		// Create an alias for the file name
-		fs.Databases[f.Name()] = &fdb
-
-		// Create an alias for the "matches" attribute
-		fs.Databases[fdb.Matches] = &fdb
+		// add the database
+		fs.Databases = append(fs.Databases, &fdb)
 	}
 
 	return nil

--- a/nition_test.go
+++ b/nition_test.go
@@ -10,7 +10,7 @@ func TestLoad(t *testing.T) {
 	if err != nil {
 		t.Errorf("LoadFingerprints() failed: %s", err)
 	}
-	if len(fset.Databases) == 0 {
+	if len(fset.DatabasesByMatchKey) == 0 {
 		t.Errorf("LoadFingerprints() returned an empty set")
 	}
 }
@@ -24,7 +24,7 @@ func TestLoadDir(t *testing.T) {
 	if err != nil {
 		t.Errorf("LoadFingerprintsDir() failed: %s", err)
 	}
-	if len(fset.Databases) == 0 {
+	if len(fset.DatabasesByMatchKey) == 0 {
 		t.Errorf("LoadFingerprintsDir() returned an empty set")
 	}
 }
@@ -35,14 +35,16 @@ func TestExamples(t *testing.T) {
 		t.Errorf("LoadFingerprints() failed")
 		return
 	}
-	if len(fset.Databases) == 0 {
+	if len(fset.DatabasesByMatchKey) == 0 {
 		t.Errorf("LoadFingerprints() returned an empty set")
 		return
 	}
-	for _, fdb := range fset.Databases {
-		err := fdb.VerifyExamples(".")
-		if err != nil {
-			t.Errorf("VerifyExamples() failed for %s: %s", fdb.Name, err)
+	for _, fdbs := range fset.DatabasesByMatchKey {
+		for _, fdb := range fdbs {
+			err := fdb.VerifyExamples(".")
+			if err != nil {
+				t.Errorf("VerifyExamples() failed for %s: %s", fdb.Name, err)
+			}
 		}
 	}
 }
@@ -53,13 +55,13 @@ func TestPJL(t *testing.T) {
 		t.Errorf("LoadFingerprints() failed")
 		return
 	}
-	if len(fset.Databases) == 0 {
+	if len(fset.DatabasesByMatchKey) == 0 {
 		t.Errorf("LoadFingerprints() returned an empty set")
 		return
 	}
 
-	m := fset.MatchFirst("hp_pjl_id.xml", "Xerox ColorQube 8570DT")
-	if !m.Matched {
+	m, _ := fset.MatchFirst("hp_pjl_id.xml", "Xerox ColorQube 8570DT")
+	if m == nil {
 		t.Errorf("Failed to match 'Xerox ColorQube 8570DT': %#v", m)
 		return
 	}
@@ -75,23 +77,20 @@ func TestPJLv2(t *testing.T) {
 		t.Errorf("LoadFingerprints() failed")
 		return
 	}
-	if len(fset.Databases) == 0 {
+	if len(fset.DatabasesByMatchKey) == 0 {
 		t.Errorf("LoadFingerprints() returned an empty set")
 		return
 	}
 
-	ms := fset.MatchAll("hp_pjl_id.xml", "Xerox ColorQube 8570DT")
+	ms, err := fset.MatchAll("hp_pjl_id.xml", "Xerox ColorQube 8570DT")
 	if len(ms) == 0 {
 		t.Errorf("Failed to match 'Xerox ColorQube 8570DT'")
 	}
-
-	m := ms[0]
-
-	if !m.Matched {
-		t.Errorf("Failed to match 'Xerox ColorQube 8570DT'")
-		return
+	if err != nil {
+		t.Errorf("MatchAll() failed: %s", err)
 	}
 
+	m := ms[0]
 	if m.Values["os.product"] != "8570DT" || m.Values["os.vendor"] != "Xerox" {
 		t.Errorf("Failed to match 'Xerox ColorQube 8570DT' expected product or vendor")
 	}
@@ -103,13 +102,13 @@ func TestHTMLTitle(t *testing.T) {
 		t.Errorf("LoadFingerprints() failed")
 		return
 	}
-	if len(fset.Databases) == 0 {
+	if len(fset.DatabasesByMatchKey) == 0 {
 		t.Errorf("LoadFingerprints() returned an empty set")
 		return
 	}
 
-	m := fset.MatchFirst("html_title.xml", "CloudKey")
-	if !m.Matched {
+	m, _ := fset.MatchFirst("html_title.xml", "CloudKey")
+	if m == nil {
 		t.Errorf("Failed to match 'CloudKey': %#v", m)
 		return
 	}
@@ -124,13 +123,13 @@ func TestX509Subjects(t *testing.T) {
 		t.Errorf("LoadFingerprints() failed")
 		return
 	}
-	if len(fset.Databases) == 0 {
+	if len(fset.DatabasesByMatchKey) == 0 {
 		t.Errorf("LoadFingerprints() returned an empty set")
 		return
 	}
 
-	m := fset.MatchFirst("x509.subject", "CN=iDRACdefault0023AEF89AD1,OU=iDRAC Group,O=Dell Inc.,L=Round Rock,C=US")
-	if !m.Matched {
+	m, _ := fset.MatchFirst("x509.subject", "CN=iDRACdefault0023AEF89AD1,OU=iDRAC Group,O=Dell Inc.,L=Round Rock,C=US")
+	if m == nil {
 		t.Errorf("Failed to match 'CN=iDRACdefault0023AEF89AD1,OU=iDRAC Group,O=Dell Inc.,L=Round Rock,C=US': %#v", m)
 		return
 	}

--- a/nition_test.go
+++ b/nition_test.go
@@ -39,10 +39,10 @@ func TestExamples(t *testing.T) {
 		t.Errorf("LoadFingerprints() returned an empty set")
 		return
 	}
-	for name, fdb := range fset.Databases {
+	for _, fdb := range fset.Databases {
 		err := fdb.VerifyExamples(".")
 		if err != nil {
-			t.Errorf("VerifyExamples() failed for %s: %s", name, err)
+			t.Errorf("VerifyExamples() failed for %s: %s", fdb.Name, err)
 		}
 	}
 }


### PR DESCRIPTION
- Removes the `Matches` attribute on the `FingerprintMatch` object. When no match is found, you now get an `error` (or an empty slice if you're using a function that can return multiple matches).
- Fixes a bug with how fingerprint databases (xml files) were handled where databases that have the same `matches` key would not be used (due to a `map[string]*FingerprintDB` setting the match key as a string. Now it is tracked with a list of `[]*FingerprintDB`)